### PR TITLE
Core-r7: Make GIC and TIM configurable

### DIFF
--- a/CMSIS/Core_R/Include/core_cr4.h
+++ b/CMSIS/Core_R/Include/core_cr4.h
@@ -47,8 +47,14 @@
 #define __FPU_PRESENT           0U
 #endif
 
+#ifndef __GIC_PRESENT
 #define __GIC_PRESENT           0U
+#endif
+
+#ifndef __TIM_PRESENT
 #define __TIM_PRESENT           0U
+#endif
+
 #define __MPU_PRESENT           1U
 
 /* Include Cortex-R Common Peripheral Access Layer header */

--- a/CMSIS/Core_R/Include/core_cr5.h
+++ b/CMSIS/Core_R/Include/core_cr5.h
@@ -47,8 +47,14 @@
 #define __FPU_PRESENT           0U
 #endif
 
+#ifndef __GIC_PRESENT
 #define __GIC_PRESENT           0U
+#endif
+
+#ifndef __TIM_PRESENT
 #define __TIM_PRESENT           0U
+#endif
+
 #define __MPU_PRESENT           1U
 
 /* Include Cortex-R Common Peripheral Access Layer header */

--- a/CMSIS/Core_R/Include/core_cr52.h
+++ b/CMSIS/Core_R/Include/core_cr52.h
@@ -47,8 +47,14 @@
 #define __FPU_PRESENT           1U
 #endif
 
+#ifndef __GIC_PRESENT
 #define __GIC_PRESENT           1U
+#endif
+
+#ifndef __TIM_PRESENT
 #define __TIM_PRESENT           1U
+#endif
+
 #define __MPU_PRESENT           1U
 
 /* Include Cortex-R Common Peripheral Access Layer header */

--- a/CMSIS/Core_R/Include/core_cr7.h
+++ b/CMSIS/Core_R/Include/core_cr7.h
@@ -47,8 +47,14 @@
 #define __FPU_PRESENT           0U
 #endif
 
+#ifndef __GIC_PRESENT
 #define __GIC_PRESENT           1U
+#endif
+
+#ifndef __TIM_PRESENT
 #define __TIM_PRESENT           1U
+#endif
+
 #define __MPU_PRESENT           1U
 
 /* Include Cortex-R Common Peripheral Access Layer header */

--- a/CMSIS/Core_R/Include/core_cr8.h
+++ b/CMSIS/Core_R/Include/core_cr8.h
@@ -47,8 +47,14 @@
 #define __FPU_PRESENT           0U
 #endif
 
+#ifndef __GIC_PRESENT
 #define __GIC_PRESENT           1U
+#endif
+
+#ifndef __TIM_PRESENT
 #define __TIM_PRESENT           1U
+#endif
+
 #define __MPU_PRESENT           1U
 
 /* Include Cortex-R Common Peripheral Access Layer header */


### PR DESCRIPTION
This is a preliminary change in order to introduce Cortex R7 support in Zephyr.

When including core_cr7.h from zehyr, compiler complains about undefined GIC_BASE and TIMER_BASE,
but GIC already have a driver in zephyr which just works with Cortex-R7 and a different timer than the
private timer may be used.

Give the choice the the soc definition to enable or disable GIC, and Timer implementation of the cmsis package.