### PR TITLE
DSP: Support compiling on native posix

### DIFF
--- a/CMSIS/DSP/CMakeLists.txt
+++ b/CMSIS/DSP/CMakeLists.txt
@@ -8,3 +8,5 @@ if(CONFIG_CMSIS_DSP_HELIUM OR CONFIG_CMSIS_DSP_MVEF OR CONFIG_CMSIS_DSP_SUPPORT)
 endif()
 
 add_subdirectory(Source)
+
+zephyr_compile_definitions_ifdef(CONFIG_ARCH_POSIX __GNUC_PYTHON__)


### PR DESCRIPTION
This commit adds support to compile cmsis-dsp
library on the host. The only definition that is
needed is `__GNUC_PYTHON__`. This makes the library
support compilation for native.

Signed-off-by: Shlomi Vaknin <shlomi.39sd@gmail.com>