### PR TITLE
DSP: fix compiler warning on inline attribute

### DIFF
--- a/CMSIS/DSP/Include/arm_math.h
+++ b/CMSIS/DSP/Include/arm_math.h
@@ -381,8 +381,8 @@ extern "C"
 #elif defined (__GNUC_PYTHON__)
 #include <stdint.h>
 #define  __ALIGNED(x) __attribute__((aligned(x)))
-#define __STATIC_FORCEINLINE static __attribute__((inline))
-#define __STATIC_INLINE static __attribute__((inline))
+#define __STATIC_FORCEINLINE static inline __attribute__((always_inline))
+#define __STATIC_INLINE static inline
 #pragma GCC diagnostic ignored "-Wunused-function"
 #pragma GCC diagnostic ignored "-Wattributes"
 


### PR DESCRIPTION
When trying to compile the distance test on zephyr,
The compiler reports: "warning: 'inline' attribute
directive ignored". To fix this, we use `static inline`
explicitly instead on using the `attribute` flag.

Signed-off-by: Shlomi Vaknin <shlomi.39sd@gmail.com>