### PR TITLE
DSP: Fix stale reference to `CONFIG_CMSIS_DSP_MVEF`

### DIFF
--- a/CMSIS/DSP/CMakeLists.txt
+++ b/CMSIS/DSP/CMakeLists.txt
@@ -3,7 +3,7 @@
 
 zephyr_include_directories(Include)
 
-if(CONFIG_CMSIS_DSP_HELIUM OR CONFIG_CMSIS_DSP_MVEF OR CONFIG_CMSIS_DSP_SUPPORT)
+if(CONFIG_ARMV8_1_M_MVEF OR CONFIG_CMSIS_DSP_SUPPORT)
   include_directories(PrivateInclude)
 endif()
 


### PR DESCRIPTION
This commit fixes the stale references to the `CONFIG_CMSIS_DSP_MVEF`
and `CONFIG_CMSIS_DSP_HELIUM` Kconfig symbols, which were replaced with
the arch-level symbol `CONFIG_ARMV8_1_M_MVEF`.

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>