### PR TITLE
Fix MVE function implementations

### DIFF
--- a/CMSIS/DSP/CMakeLists.txt
+++ b/CMSIS/DSP/CMakeLists.txt
@@ -3,7 +3,7 @@
 
 zephyr_include_directories(Include)
 
-if(CONFIG_CMSIS_DSP_HELIUM OR CONFIG_CMSIS_DSP_MVEF OR CONFIG_CMSIS_DSP_SUPPORT)
+if(CONFIG_ARMV8_1_M_MVEF OR CONFIG_CMSIS_DSP_SUPPORT)
   include_directories(PrivateInclude)
 endif()
 

--- a/CMSIS/DSP/PrivateInclude/arm_vec_fft.h
+++ b/CMSIS/DSP/PrivateInclude/arm_vec_fft.h
@@ -140,7 +140,7 @@ __STATIC_INLINE void arm_bitreversal_16_inpl_mve(
 {
     uint32_t       *src = (uint32_t *) pSrc;
     int32_t         blkCnt;     /* loop counters */
-    uint32x4_t      bitRevTabOff;
+    uint16x8_t      bitRevTabOff;
     uint16x8_t      one = vdupq_n_u16(1);
     uint32x4_t      bitRevOff1Low, bitRevOff0Low;
     uint32x4_t      bitRevOff1High, bitRevOff0High;
@@ -152,8 +152,8 @@ __STATIC_INLINE void arm_bitreversal_16_inpl_mve(
 
     bitRevOff0Low = vmullbq_int_u16(bitRevTabOff, one);
     bitRevOff0High = vmulltq_int_u16(bitRevTabOff, one);
-    bitRevOff0Low = vshrq_n_u16(bitRevOff0Low, 3);
-    bitRevOff0High = vshrq_n_u16(bitRevOff0High, 3);
+    bitRevOff0Low = (uint32x4_t)vshrq_n_u16((uint16x8_t)bitRevOff0Low, 3);
+    bitRevOff0High = (uint32x4_t)vshrq_n_u16((uint16x8_t)bitRevOff0High, 3);
 
     blkCnt = (bitRevLen / 16);
     while (blkCnt > 0) {
@@ -162,8 +162,8 @@ __STATIC_INLINE void arm_bitreversal_16_inpl_mve(
 
         bitRevOff1Low = vmullbq_int_u16(bitRevTabOff, one);
         bitRevOff1High = vmulltq_int_u16(bitRevTabOff, one);
-        bitRevOff1Low = vshrq_n_u16(bitRevOff1Low, 3);
-        bitRevOff1High = vshrq_n_u16(bitRevOff1High, 3);
+        bitRevOff1Low = (uint32x4_t)vshrq_n_u16((uint16x8_t)bitRevOff1Low, 3);
+        bitRevOff1High = (uint32x4_t)vshrq_n_u16((uint16x8_t)bitRevOff1High, 3);
 
         inLow = vldrwq_gather_shifted_offset_u32(src, bitRevOff0Low);
         inHigh = vldrwq_gather_shifted_offset_u32(src, bitRevOff0High);
@@ -177,8 +177,8 @@ __STATIC_INLINE void arm_bitreversal_16_inpl_mve(
 
         bitRevOff0Low = vmullbq_int_u16(bitRevTabOff, one);
         bitRevOff0High = vmulltq_int_u16(bitRevTabOff, one);
-        bitRevOff0Low = vshrq_n_u16(bitRevOff0Low, 3);
-        bitRevOff0High = vshrq_n_u16(bitRevOff0High, 3);
+        bitRevOff0Low = (uint32x4_t)vshrq_n_u16((uint16x8_t)bitRevOff0Low, 3);
+        bitRevOff0High = (uint32x4_t)vshrq_n_u16((uint16x8_t)bitRevOff0High, 3);
 
         inLow = vldrwq_gather_shifted_offset_u32(src, bitRevOff1Low);
         inHigh = vldrwq_gather_shifted_offset_u32(src, bitRevOff1High);
@@ -211,8 +211,8 @@ __STATIC_INLINE void arm_bitreversal_16_inpl_mve(
 
         bitRevOff0Low = vmullbq_int_u16(bitRevTabOff, one);
         bitRevOff0High = vmulltq_int_u16(bitRevTabOff, one);
-        bitRevOff0Low = vshrq_n_u16(bitRevOff0Low, 3);
-        bitRevOff0High = vshrq_n_u16(bitRevOff0High, 3);
+        bitRevOff0Low = (uint32x4_t)vshrq_n_u16((uint16x8_t)bitRevOff0Low, 3);
+        bitRevOff0High = (uint32x4_t)vshrq_n_u16((uint16x8_t)bitRevOff0High, 3);
 
         inLow = vldrwq_gather_shifted_offset_z_u32(src, bitRevOff0Low, p);
         inHigh = vldrwq_gather_shifted_offset_z_u32(src, bitRevOff0High, p);
@@ -251,13 +251,13 @@ __STATIC_INLINE void arm_bitreversal_32_outpl_mve(void *pDst, void *pSrc, uint32
     while (blkCnt > 0) {
         uint64x2_t      vecIn;
 
-        vecIn = vldrdq_gather_offset_u64(pSrc, (int64x2_t) bitRevOffs0);
+        vecIn = vldrdq_gather_offset_u64(pSrc, (uint64x2_t) bitRevOffs0);
         idxOffs0 = idxOffs0 + 16;
         vst1q(pDst32, (uint32x4_t) vecIn);
         pDst32 += 4;
         bitRevOffs0 = vbrsrq(idxOffs0, bitRevPos);
 
-        vecIn = vldrdq_gather_offset_u64(pSrc, (int64x2_t) bitRevOffs1);
+        vecIn = vldrdq_gather_offset_u64(pSrc, (uint64x2_t) bitRevOffs1);
         idxOffs1 = idxOffs1 + 16;
         vst1q(pDst32, (uint32x4_t) vecIn);
         pDst32 += 4;
@@ -297,13 +297,13 @@ __STATIC_INLINE void arm_bitreversal_16_outpl_mve(void *pDst, void *pSrc, uint32
     while (blkCnt > 0) {
         uint32x4_t      vecIn;
 
-        vecIn = vldrwq_gather_offset_s32(pSrc, bitRevOffs0);
+        vecIn = (uint32x4_t)vldrwq_gather_offset_s32(pSrc, bitRevOffs0);
         idxOffs0 = idxOffs0 + 32;
         vst1q(pDst16, (uint16x8_t) vecIn);
         pDst16 += 8;
         bitRevOffs0 = vbrsrq(idxOffs0, bitRevPos);
 
-        vecIn = vldrwq_gather_offset_s32(pSrc, bitRevOffs1);
+        vecIn = (uint32x4_t)vldrwq_gather_offset_s32(pSrc, bitRevOffs1);
         idxOffs1 = idxOffs1 + 32;
         vst1q(pDst16, (uint16x8_t) vecIn);
         pDst16 += 8;

--- a/CMSIS/DSP/Source/FilteringFunctions/arm_biquad_cascade_df1_32x64_q31.c
+++ b/CMSIS/DSP/Source/FilteringFunctions/arm_biquad_cascade_df1_32x64_q31.c
@@ -296,7 +296,7 @@ void arm_biquad_cas_df1_32x64_q31(
     q31_t     b0, b1, b2, a1, a2;   /*  Filter coefficients           */
     int32_t   shift = (int32_t) S->postShift + 1;   /*  Shift to be applied to the output */
     uint32_t  sample, stage = S->numStages; /*  loop counters                     */
-    q31x4_t vecCoef, vecIn;
+    q31x4_t vecCoef = { 0 }, vecIn;
     q63_t     acc;
 
     if (blockSize <= 3)

--- a/CMSIS/DSP/Source/FilteringFunctions/arm_biquad_cascade_df1_f16.c
+++ b/CMSIS/DSP/Source/FilteringFunctions/arm_biquad_cascade_df1_f16.c
@@ -63,7 +63,7 @@ void arm_biquad_cascade_df1_f16(
     const float16_t *pCoeffs = S->pCoeffs;    /*  coefficient pointer       */
     float16_t Xn1, Xn2, Yn1, Yn2;   /*  Filter pState variables   */
     float16_t X0, X1, X2, X3;   /*  temporary input           */
-    float16_t X4, X5, X6, X7;   /*  temporary input           */
+    float16_t X4, X5, X6, X7 = 0;   /*  temporary input           */
     _Float16 lastX, lastY;             /*  X,Y history for tail handling */
     f16x8_t coeffs;
     f16x8_t accVec;           /* accumultor vector */

--- a/CMSIS/DSP/Source/FilteringFunctions/arm_biquad_cascade_df1_f32.c
+++ b/CMSIS/DSP/Source/FilteringFunctions/arm_biquad_cascade_df1_f32.c
@@ -176,7 +176,7 @@ void arm_biquad_cascade_df1_f32(
     const float32_t *pCoeffs = S->pCoeffs;    /*  coefficient pointer       */
     float32_t Xn1, Xn2, Yn1, Yn2;       /*  Filter pState variables   */
     float32_t lastX, lastY;             /*  X,Y history for tail handling */
-    float32_t X0, X1, X2, X3;           /*  temporary input           */
+    float32_t X0, X1, X2, X3 = 0;       /*  temporary input           */
     f32x4_t coeffs;
     f32x4_t accVec;                   /* accumultor vector */
     uint32_t  sample, stage = S->numStages; /*  loop counters             */

--- a/CMSIS/DSP/Source/FilteringFunctions/arm_biquad_cascade_df1_q15.c
+++ b/CMSIS/DSP/Source/FilteringFunctions/arm_biquad_cascade_df1_q15.c
@@ -102,9 +102,9 @@ void arm_biquad_cascade_df1_q15(
         bCoeffs1[7] = a2;
         bCoeffs1[6] = a1;
 
-        bCoeffs2 =
+        bCoeffs2 = (q15x8_t)
             vsetq_lane_s32(vgetq_lane_s32((q31x4_t) bCoeffs0, 3), (q31x4_t) bCoeffs2, 3);
-        bCoeffs3 =
+        bCoeffs3 = (q15x8_t)
             vsetq_lane_s32(vgetq_lane_s32((q31x4_t) bCoeffs1, 3), (q31x4_t) bCoeffs3, 3);
 
 

--- a/CMSIS/DSP/Source/FilteringFunctions/arm_biquad_cascade_df1_q31.c
+++ b/CMSIS/DSP/Source/FilteringFunctions/arm_biquad_cascade_df1_q31.c
@@ -69,7 +69,7 @@ void arm_biquad_cascade_df1_q31(
     uint32_t        stages = S->numStages;      /*  loop counters                 */
     int             postShift = S->postShift;
     q31x4_t         b0Coeffs, b1Coeffs, a0Coeffs, a1Coeffs;     /*  Coefficients vector           */
-    q31x4_t         stateVec;
+    q31x4_t         stateVec = { 0 };
     q31_t          *pState = S->pState; /*  pState pointer initialization */
     q31x4_t         inVec0;
     int64_t         acc;

--- a/CMSIS/DSP/Source/FilteringFunctions/arm_biquad_cascade_stereo_df2T_f16.c
+++ b/CMSIS/DSP/Source/FilteringFunctions/arm_biquad_cascade_stereo_df2T_f16.c
@@ -48,7 +48,7 @@
  */
 
 #if defined(ARM_MATH_MVE_FLOAT16) && !defined(ARM_MATH_AUTOVECTORIZE) && defined(__CMSIS_GCC_H)
-#pragma GCC warning "Scalar version of arm_biquad_cascade_stereo_df2T_f16 built. Helium version has build issues with gcc."
+#pragma message "Scalar version of arm_biquad_cascade_stereo_df2T_f16 built. Helium version has build issues with gcc."
 #endif 
 
 #if (defined(ARM_MATH_MVE_FLOAT16) && defined(ARM_MATH_HELIUM_EXPERIMENTAL)) && !defined(ARM_MATH_AUTOVECTORIZE) && !defined(__CMSIS_GCC_H)

--- a/CMSIS/DSP/Source/FilteringFunctions/arm_fir_decimate_f32.c
+++ b/CMSIS/DSP/Source/FilteringFunctions/arm_fir_decimate_f32.c
@@ -142,7 +142,7 @@ void arm_fir_decimate_f32(
     uint32_t  i, tapCnt, blkCnt, outBlockSize = blockSize / S->M;   /* Loop counters */
     uint32_t  blkCntN4;
     const float32_t *px0, *px1, *px2, *px3;
-    f32x4_t accv, acc0v, acc1v, acc2v, acc3v;
+    f32x4_t accv = { 0 }, acc0v, acc1v, acc2v, acc3v;
     f32x4_t x0v, x1v, x2v, x3v;
     f32x4_t c0v;
 

--- a/CMSIS/DSP/Source/FilteringFunctions/arm_levinson_durbin_f16.c
+++ b/CMSIS/DSP/Source/FilteringFunctions/arm_levinson_durbin_f16.c
@@ -52,7 +52,7 @@
  */
 
 #if defined(ARM_MATH_MVE_FLOAT16) && !defined(ARM_MATH_AUTOVECTORIZE) && defined(__CMSIS_GCC_H)
-#pragma GCC warning "Scalar version of arm_levinson_durbin_f16 built. Helium version has build issues with gcc."
+#pragma message "Scalar version of arm_levinson_durbin_f16 built. Helium version has build issues with gcc."
 #endif 
 
 #if defined(ARM_MATH_MVE_FLOAT16) && !defined(ARM_MATH_AUTOVECTORIZE) &&  !defined(__CMSIS_GCC_H)

--- a/CMSIS/DSP/Source/FilteringFunctions/arm_levinson_durbin_f32.c
+++ b/CMSIS/DSP/Source/FilteringFunctions/arm_levinson_durbin_f32.c
@@ -52,7 +52,7 @@
  */
 
 #if defined(ARM_MATH_MVE_FLOAT16) && !defined(ARM_MATH_AUTOVECTORIZE) && defined(__CMSIS_GCC_H)
-#pragma GCC warning "Scalar version of arm_levinson_durbin_f32 built. Helium version has build issues with gcc."
+#pragma message "Scalar version of arm_levinson_durbin_f32 built. Helium version has build issues with gcc."
 #endif 
 
 #if defined(ARM_MATH_MVEF) && !defined(ARM_MATH_AUTOVECTORIZE) &&  !defined(__CMSIS_GCC_H)

--- a/CMSIS/DSP/Source/FilteringFunctions/arm_levinson_durbin_q31.c
+++ b/CMSIS/DSP/Source/FilteringFunctions/arm_levinson_durbin_q31.c
@@ -113,7 +113,7 @@ __STATIC_FORCEINLINE q31_t divide(q31_t n, q31_t d)
  */
 
 #if defined(ARM_MATH_MVE_FLOAT16) && !defined(ARM_MATH_AUTOVECTORIZE) && defined(__CMSIS_GCC_H)
-#pragma GCC warning "Scalar version of arm_levinson_durbin_q31 built. Helium version has build issues with gcc."
+#pragma message "Scalar version of arm_levinson_durbin_q31 built. Helium version has build issues with gcc."
 #endif 
 
 #if defined(ARM_MATH_MVEI) && !defined(ARM_MATH_AUTOVECTORIZE) &&  !defined(__CMSIS_GCC_H)

--- a/CMSIS/DSP/Source/MatrixFunctions/arm_mat_cmplx_mult_f16.c
+++ b/CMSIS/DSP/Source/MatrixFunctions/arm_mat_cmplx_mult_f16.c
@@ -52,7 +52,7 @@
  */
 
 #if defined(ARM_MATH_MVE_FLOAT16) && !defined(ARM_MATH_AUTOVECTORIZE) && defined(__CMSIS_GCC_H)
-#pragma GCC warning "Scalar version of arm_mat_cmplx_mult_f16 built. Helium version has build issues with gcc."
+#pragma message "Scalar version of arm_mat_cmplx_mult_f16 built. Helium version has build issues with gcc."
 #endif 
 
 #if defined(ARM_MATH_MVE_FLOAT16) && !defined(ARM_MATH_AUTOVECTORIZE) &&  !defined(__CMSIS_GCC_H)

--- a/CMSIS/DSP/Source/MatrixFunctions/arm_mat_ldlt_f32.c
+++ b/CMSIS/DSP/Source/MatrixFunctions/arm_mat_ldlt_f32.c
@@ -178,7 +178,7 @@ arm_status arm_mat_ldlt_f32(
 
         int32x4_t vecOffs;
         int w;
-        vecOffs = vidupq_u32((uint32_t)0, 1);
+        vecOffs = (int32x4_t)vidupq_u32((uint32_t)0, 1);
         vecOffs = vmulq_n_s32(vecOffs,n);
 
         for(w=k+1; w<n; w+=4)
@@ -204,7 +204,7 @@ arm_status arm_mat_ldlt_f32(
              //pA[w*n+x] = pA[w*n+x] - pA[w*n+k] * (pA[x*n+k] * invA);
 
 
-             vecX = vldrwq_gather_shifted_offset_z_f32(&pA[x*n+k], vecOffs, p0);
+             vecX = vldrwq_gather_shifted_offset_z_f32(&pA[x*n+k], (uint32x4_t)vecOffs, p0);
              vecX = vmulq_m_n_f32(vuninitializedq_f32(),vecX,invA,p0);
 
              
@@ -247,7 +247,7 @@ arm_status arm_mat_ldlt_f32(
 
              vecA = vldrwq_z_f32(&pA[w*n+x],p0);
              
-             vecX = vldrwq_gather_shifted_offset_z_f32(&pA[x*n+k], vecOffs, p0);
+             vecX = vldrwq_gather_shifted_offset_z_f32(&pA[x*n+k], (uint32x4_t)vecOffs, p0);
              vecX = vmulq_m_n_f32(vuninitializedq_f32(),vecX,invA,p0);
 
              vecA = vfmsq_m(vecA, vecW, vecX, p0);

--- a/CMSIS/DSP/Source/SupportFunctions/arm_f16_to_float.c
+++ b/CMSIS/DSP/Source/SupportFunctions/arm_f16_to_float.c
@@ -54,7 +54,7 @@
  */
 
 #if defined(ARM_MATH_MVE_FLOAT16) && !defined(ARM_MATH_AUTOVECTORIZE) && defined(__CMSIS_GCC_H)
-#pragma GCC warning "Scalar version of arm_f16_to_float built. Helium version has build issues with gcc."
+#pragma message "Scalar version of arm_f16_to_float built. Helium version has build issues with gcc."
 #endif 
 
 #if defined(ARM_MATH_MVE_FLOAT16) && !defined(ARM_MATH_AUTOVECTORIZE) &&  !defined(__CMSIS_GCC_H)

--- a/CMSIS/DSP/Source/SupportFunctions/arm_float_to_f16.c
+++ b/CMSIS/DSP/Source/SupportFunctions/arm_float_to_f16.c
@@ -50,7 +50,7 @@
  */
 
 #if defined(ARM_MATH_MVE_FLOAT16) && !defined(ARM_MATH_AUTOVECTORIZE) && defined(__CMSIS_GCC_H)
-#pragma GCC warning "Scalar version of arm_float_to_f16 built. Helium version has build issues with gcc."
+#pragma message "Scalar version of arm_float_to_f16 built. Helium version has build issues with gcc."
 #endif 
 
 #if defined(ARM_MATH_MVE_FLOAT16) && !defined(ARM_MATH_AUTOVECTORIZE) &&  !defined(__CMSIS_GCC_H)

--- a/CMSIS/DSP/Source/SupportFunctions/arm_q15_to_float.c
+++ b/CMSIS/DSP/Source/SupportFunctions/arm_q15_to_float.c
@@ -72,9 +72,9 @@ void arm_q15_to_float(
   {
       /* C = (float32_t) A / 32768 */
       /* convert from q15 to float and then store the results in the destination buffer */
-      vecDst = vldrhq_s32(pSrcVec); 
+      vecDst = (q15x8_t)vldrhq_s32(pSrcVec); 
       pSrcVec += 4;
-      vstrwq(pDst, vcvtq_n_f32_s32(vecDst, 15));  
+      vstrwq(pDst, vcvtq_n_f32_s32((int32x4_t)vecDst, 15));  
       pDst += 4;
       /*
        * Decrement the blockSize loop counter

--- a/CMSIS/DSP/Source/SupportFunctions/arm_q7_to_float.c
+++ b/CMSIS/DSP/Source/SupportFunctions/arm_q7_to_float.c
@@ -70,9 +70,9 @@ void arm_q7_to_float(
     {
         /* C = (float32_t) A / 32768 */
         /* convert from q7 to float and then store the results in the destination buffer */
-        vecDst = vldrbq_s32(pSrcVec);    
+        vecDst = (q7x16_t)vldrbq_s32(pSrcVec);    
         pSrcVec += 4;
-        vstrwq(pDst, vcvtq_n_f32_s32(vecDst, 7));   
+        vstrwq(pDst, vcvtq_n_f32_s32((int32x4_t)vecDst, 7));   
         pDst += 4;
         /*
          * Decrement the blockSize loop counter

--- a/CMSIS/DSP/Source/TransformFunctions/arm_cfft_q15.c
+++ b/CMSIS/DSP/Source/TransformFunctions/arm_cfft_q15.c
@@ -184,16 +184,16 @@ static void _arm_radix4_butterfly_q15_mve(
         vecC = (q15x8_t) vldrwq_gather_base_s32(vecScGathAddr, 8);
 
         vecTmp0 = vhaddq(vecSum0, vecSum1);
-        vstrwq_scatter_base_s32(vecScGathAddr, -64, (q15x8_t) vecTmp0);
+        vstrwq_scatter_base_s32(vecScGathAddr, -64, (int32x4_t) vecTmp0);
 
         vecTmp0 = vhsubq(vecSum0, vecSum1);
-        vstrwq_scatter_base_s32(vecScGathAddr, -64 + 4, (q15x8_t) vecTmp0);
+        vstrwq_scatter_base_s32(vecScGathAddr, -64 + 4, (int32x4_t) vecTmp0);
 
         vecTmp0 = MVE_CMPLX_SUB_FX_A_ixB(vecDiff0, vecDiff1);
-        vstrwq_scatter_base_s32(vecScGathAddr, -64 + 8, (q15x8_t) vecTmp0);
+        vstrwq_scatter_base_s32(vecScGathAddr, -64 + 8, (int32x4_t) vecTmp0);
 
         vecTmp0 = MVE_CMPLX_ADD_FX_A_ixB(vecDiff0, vecDiff1);
-        vstrwq_scatter_base_s32(vecScGathAddr, -64 + 12, (q15x8_t) vecTmp0);
+        vstrwq_scatter_base_s32(vecScGathAddr, -64 + 12, (int32x4_t) vecTmp0);
 
         blkCnt--;
     }
@@ -419,16 +419,16 @@ static void _arm_radix4_butterfly_inverse_q15_mve(const arm_cfft_instance_q15 *S
         vecC = (q15x8_t) vldrwq_gather_base_s32(vecScGathAddr, 8);
 
         vecTmp0 = vhaddq(vecSum0, vecSum1);
-        vstrwq_scatter_base_s32(vecScGathAddr, -64, (q15x8_t) vecTmp0);
+        vstrwq_scatter_base_s32(vecScGathAddr, -64, (int32x4_t) vecTmp0);
 
         vecTmp0 = vhsubq(vecSum0, vecSum1);
-        vstrwq_scatter_base_s32(vecScGathAddr, -64 + 4, (q15x8_t) vecTmp0);
+        vstrwq_scatter_base_s32(vecScGathAddr, -64 + 4, (int32x4_t) vecTmp0);
 
         vecTmp0 = MVE_CMPLX_ADD_FX_A_ixB(vecDiff0, vecDiff1);
-        vstrwq_scatter_base_s32(vecScGathAddr, -64 + 8, (q15x8_t) vecTmp0);
+        vstrwq_scatter_base_s32(vecScGathAddr, -64 + 8, (int32x4_t) vecTmp0);
 
         vecTmp0 = MVE_CMPLX_SUB_FX_A_ixB(vecDiff0, vecDiff1);
-        vstrwq_scatter_base_s32(vecScGathAddr, -64 + 12, (q15x8_t) vecTmp0);
+        vstrwq_scatter_base_s32(vecScGathAddr, -64 + 12, (int32x4_t) vecTmp0);
 
         blkCnt--;
     }


### PR DESCRIPTION
This series fixes the invalid MVE configuration references and the type mismatches in the MVE vector function implementations that cause compiler errors with GCC.

