### PR TITLE
Remove unused variable when using aarch64

### DIFF
--- a/CMSIS/DSP/CMakeLists.txt
+++ b/CMSIS/DSP/CMakeLists.txt
@@ -9,4 +9,4 @@ endif()
 
 add_subdirectory(Source)
 
-zephyr_compile_definitions_ifdef(CONFIG_ARCH_POSIX __GNUC_PYTHON__)
+zephyr_compile_definitions_ifndef(CONFIG_ARM __GNUC_PYTHON__)

--- a/CMSIS/DSP/Source/BasicMathFunctions/arm_dot_prod_f32.c
+++ b/CMSIS/DSP/Source/BasicMathFunctions/arm_dot_prod_f32.c
@@ -132,7 +132,9 @@ void arm_dot_prod_f32(
     f32x4_t vec1;
     f32x4_t vec2;
     f32x4_t accum = vdupq_n_f32(0);   
+#if !__aarch64__
     f32x2_t tmp = vdup_n_f32(0);    
+#endif
 
     /* Compute 4 outputs at a time */
     blkCnt = blockSize >> 2U;


### PR DESCRIPTION
The `tmp` variable was unused if `!__aarch64__` and it was causing a compile warning.

Signed-off-by: Yuval Peress <peress@google.com>