### PR TITLE
zephyr: cmake/kconfig are external

### DIFF
--- a/zephyr/module.yml
+++ b/zephyr/module.yml
@@ -1,2 +1,3 @@
 build:
-  cmake: .
+  cmake-ext: true
+  kconfig-ext: true


### PR DESCRIPTION
Define module Kconfig/CMake as external, so that we can fix the entry point in $ZEPHYR_BASE/modules/cmsis. This change is needed to provide module glue header/s.