### PR TITLE
Backport CMSIS_6#102 to CMSIS 5.9.0

### DIFF
--- a/CMSIS/Core/Include/cmsis_iccarm.h
+++ b/CMSIS/Core/Include/cmsis_iccarm.h
@@ -309,13 +309,22 @@ __STATIC_FORCEINLINE void __TZ_set_STACKSEAL_S (uint32_t* stackTop) {
 
   #include "iccarm_builtin.h"
 
-  #define __disable_fault_irq __iar_builtin_disable_fiq
   #define __disable_irq       __iar_builtin_disable_interrupt
-  #define __enable_fault_irq  __iar_builtin_enable_fiq
   #define __enable_irq        __iar_builtin_enable_interrupt
   #define __arm_rsr           __iar_builtin_rsr
   #define __arm_wsr           __iar_builtin_wsr
 
+  #if (defined(__ARM_ARCH_ISA_THUMB) && __ARM_ARCH_ISA_THUMB >= 2)
+    __IAR_FT void __disable_fault_irq()
+    {
+      __ASM volatile ("CPSID F" ::: "memory");
+    }
+
+    __IAR_FT void __enable_fault_irq()
+    {
+      __ASM volatile ("CPSIE F" ::: "memory");
+    }
+  #endif
 
   #define __get_APSR()                (__arm_rsr("APSR"))
   #define __get_BASEPRI()             (__arm_rsr("BASEPRI"))
@@ -639,9 +648,15 @@ __STATIC_FORCEINLINE void __TZ_set_CONTROL_NS(uint32_t control)
     }
 
 
-    #define __enable_fault_irq  __enable_fiq
-    #define __disable_fault_irq __disable_fiq
+    __IAR_FT void __disable_fault_irq()
+    {
+      __ASM volatile ("CPSID F" ::: "memory");
+    }
 
+    __IAR_FT void __enable_fault_irq()
+    {
+      __ASM volatile ("CPSIE F" ::: "memory");
+    }
 
   #endif /* (__CORTEX_M >= 0x03) */
 


### PR DESCRIPTION
Currently CMSIS 5 is broken with the IAR compiler, and will not be patched. I tried lifting zephyr to CMSIS 6 but this was non-trivial. (my try is here: 
https://github.com/zephyrproject-rtos/zephyr/pull/84330 and https://github.com/zephyrproject-rtos/CMSIS_6/pull/1
)

One way to fix this without ugly kludges inside zephyr is backporting this fix to CMSIS 5.9.0.
https://github.com/ARM-software/CMSIS_6/pull/102

Zephyr PR is here:
https://github.com/zephyrproject-rtos/zephyr/pull/84481
Since currently there are no IAR tests or handling in zephyr I don't expect this change to break anything currently
